### PR TITLE
advent of clojure 2018, day1 part2

### DIFF
--- a/aoc-2018/day1/day1.clj
+++ b/aoc-2018/day1/day1.clj
@@ -12,3 +12,13 @@
   ;; part 1
   (map parse-long input-lines)
   (sum (map parse-long input-lines)))
+
+  ;; part2
+(->> (cycle (map parse-long input-lines))
+     (reduce
+      (fn [[seen current] change]
+        (let [next (+ current change)]
+          (if (contains? seen next)
+            (reduced next)
+            [(conj seen next) next])))
+      [#{0} 0]))

--- a/aoc-2018/day1/day1.clj
+++ b/aoc-2018/day1/day1.clj
@@ -8,13 +8,15 @@
 
 (defn sum [s] (reduce + s))
 
+
+(def input (map parse-long input-lines))
 (comment
   ;; part 1
-  (map parse-long input-lines)
-  (sum (map parse-long input-lines)))
+
+  (sum input))
 
   ;; part2
-(->> (cycle (map parse-long input-lines))
+(->> (cycle input)
      (reduce
       (fn [[seen current] change]
         (let [next (+ current change)]


### PR DESCRIPTION
## 문제를 읽고

advent of code의 day1 part2 은 늘 그렇듯이 급격히 난이도가 올라갔습니다.

처음에는 find를 써야 하나 싶었는데요. '지금까지 등장한'이라고 하면 누적되는 상태를 유지해야 하니 reduce를 쓰자고 생각했습니다.

## 풀면서

처음에는 중간에 원하는 값을 찾아도 끝까지 가야한다 생각해서 이미 값을 찾았으면 현재 값을 유지한다... 같은 재귀로 로직을 짰습니다. 좀 이상하더라고요.

그래서 reduce를 중간에 멈추는 법을 찾아보니 reduced가 있었습니다. 오호 이거 좋군. 하고 쓰긴 했는데 이건 break처럼 명령적인 것인지 선언적인 것인지 고민이 들었습니다. (제 생각에는 선언적인 것 같습니다)

그런데 답이 안 나와서. 아니? 하고 문제를 읽어보니까 frequency가 계속 순환하는구나 알게 되어서. 이걸 어떻게 표현해야 하나 하고 검색해보니 cycle이 있었습니다. lazy seq 는 무적이다.

## 회고와 생각

- 원래 함수 안에서 def를 쓰기도 했는데. kondo가 inline-def 쓰지 말라고 해서 let을 쓰기 시작했습니다. 어떤 언어라도 자기만의 scope와 closure 개념이 있으니 이 부분은 좀 더 주의해서 보려 합니다.

- Alt+Enter에 의존하고 있는데. 매번 위로 가서 함수 다시 평가하고, 다시 아래의 코멘트 실행하는 게 번거롭더군요. 파일을 저장하면 바로 테스트를 실행해주는 기능을 찾아보려 합니다. (이 고민은 day3 까지 이어졌습니다)
