### PR TITLE
advent of clojure 2018, day2 part2

### DIFF
--- a/aoc-2018/day2/day2.clj
+++ b/aoc-2018/day2/day2.clj
@@ -45,10 +45,10 @@
 (defn compare-str
   [[a b]]
   (reduce
-   (fn [[diff common], [x y]]
+   (fn [[diff common] [x y]]
      (if (= x y)
-       [diff, (conj common x)]
-       [(inc diff), common]))
+       [diff (conj common x)]
+       [(inc diff) common]))
    [0, []]
    (zip a b)))
 

--- a/aoc-2018/day2/day2.clj
+++ b/aoc-2018/day2/day2.clj
@@ -36,3 +36,45 @@
 
 (comment
   (check-sum input-lines))
+
+;; part 2
+(defn zip
+  [a b]
+  (map vector a b))
+
+(defn compare-str
+  [[a b]]
+  (reduce
+   (fn [[diff common], [x y]]
+     (if (= x y)
+       [diff, (conj common x)]
+       [(inc diff), common]))
+   [0, []]
+   (zip a b)))
+
+(def t
+  ["abcde" "fghij" "fguij"])
+
+(defn combinations-2
+  [seq] ;; seq에는 중복이 없다고 가정합니다
+  (->>
+   (mapcat (fn [a] (map (fn [b] [a b]) seq)) seq) ;; flatMap + map
+   (filter (fn [[a b]] (not= a b))))) ;; 자기 자신과의 조합은 걸러줍니다
+
+(defn answer-2
+  [input]
+  (->> input
+       (combinations-2) ;; 비교하기 위해 조합을 구합니다
+       (map compare-str) ;; 비교해서 다른 글자수와 공통 부분들을 구합니다
+       (filter (fn [[diff]] (= diff 1))) ;; 1글자만 다른 것 중에
+       (distinct) ;; 중복을 제거하고
+       (first) ;; 첫 번째 항목에서
+       (second) ;; 공통부분의 문자 sequence를 꺼내서
+       (str/join) ;; 문자열로 합칩니다
+       ))
+
+;; 사실 답이 단 하나 뿐이라 가정하면 중복을 제거하지 않고 점프해도 됩니다
+
+(comment
+  (answer-2 t)
+  (answer-2 input-lines))

--- a/aoc-2018/day2/day2.clj
+++ b/aoc-2018/day2/day2.clj
@@ -38,9 +38,6 @@
   (check-sum input-lines))
 
 ;; part 2
-(defn zip
-  [a b]
-  (map vector a b))
 
 (defn compare-str
   [[a b]]
@@ -50,7 +47,7 @@
        [diff (conj common x)]
        [(inc diff) common]))
    [0, []]
-   (zip a b)))
+   (map vector a b)))
 
 (def t
   ["abcde" "fghij" "fguij"])

--- a/aoc-2018/day2/day2.clj
+++ b/aoc-2018/day2/day2.clj
@@ -4,8 +4,7 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
-(def data-file (slurp "resources/day2/input1.txt"))
-(def input-lines (str/split-lines data-file))
+(def input-lines (str/split-lines (slurp "resources/day2/input1.txt")))
 
 
 (defn check
@@ -40,6 +39,7 @@
 ;; part 2
 
 (defn compare-str
+  "a와 b 사이에 글자수 차이와 공통 부분을 튜플로 반환합니다"
   [[a b]]
   (reduce
    (fn [[diff common] [x y]]
@@ -49,22 +49,37 @@
    [0, []]
    (map vector a b)))
 
+((deftest compare-str-test
+   (testing "똑같은 경우"
+     (is (= (compare-str ["abc" "abc"])
+            [0 [\a \b \c]])))
+   (testing "1글자만 다른 경우"
+     (is (= (compare-str ["abc" "abi"])
+            [1 [\a \b]])))))
+
+
 (def t
   ["abcde" "fghij" "fguij"])
 
-(defn combinations-2
-  [seq] ;; seq에는 중복이 없다고 가정합니다
+(defn permutation-2
+  "items 중에 중복 없이 2개를 고른 순열을 반환합니다."
+  [items] ;; items에는 중복이 없다고 가정합니다
   (->>
-   (mapcat (fn [a] (map (fn [b] [a b]) seq)) seq) ;; flatMap + map
-   (filter (fn [[a b]] (not= a b))))) ;; 자기 자신과의 조합은 걸러줍니다
+   (mapcat (fn [a] (map (fn [b] [a b]) items)) items) ;; flatMap + map
+   (filter (fn [[a b]] (not= a b))) ;; 자기 자신과의 짝은 걸러줍니다
+)) ;; 순서만 다른 값들을 걸러줍니다
+
+((deftest permutation-2-test
+   (is (= (permutation-2 ["a" "b" "c"])
+          '(["a" "b"] ["a" "c"] ["b" "a"] ["b" "c"] ["c" "a"] ["c" "b"])))))
 
 (defn answer-2
   [input]
   (->> input
-       (combinations-2) ;; 비교하기 위해 조합을 구합니다
+       (permutation-2) ;; 비교하기 위해 조합을 구합니다
        (map compare-str) ;; 비교해서 다른 글자수와 공통 부분들을 구합니다
        (filter (fn [[diff]] (= diff 1))) ;; 1글자만 다른 것 중에
-       (distinct) ;; 중복을 제거하고
+       (distinct)
        (first) ;; 첫 번째 항목에서
        (second) ;; 공통부분의 문자 sequence를 꺼내서
        (str/join) ;; 문자열로 합칩니다


### PR DESCRIPTION
## 문제를 읽으며

딱 보고 단계가 복잡해질 것 같아서, 쓰레딩 매크로를 써봐야지 생각을 했습니다. 사실 저는 쓰레딩 매크로를 정말 복잡하지 않으면 선호하는 편은 아닙니다.

저는 메서드 체이닝이나 파이프 연산자 없이도 오른쪽부터 읽으면 된다 생각하던 사람이고, 함수 호출을 표현식보다는 명령적으로 생각하게 될 때도 있고, 어떤 값이 어떻게 넘어가는지 평가해보지 않으면 알기 어렵고 등등의 이유가 있습니다.

그래서 명확하게 변수 명을 주는 게 귀찮아도 더 이해하기 쉬울 때도 있지 않나 싶네요. 일단은 각 단계마다 주석을 달아두었습니다.

(그리고 문제를 읽으며 한 생각이랑 풀면서 한 생각이랑 경계가 모호하다는 생각이 듭니다)

## 풀면서

역시 파이썬을 하던 시절에 zip 과 itertools의 combination 을 유용하게 썼었습니다. 다른 언어를 쓰면서도 이 친구들을 다시 구현해서 여러 번 사용했지요. clojure에도 똑같은 게 있나 찾아봤는데...

의외로 없었습니다. 제가 못 찾은 것일 수도 있고요. 그래서 인터넷을 찾아보면서 직접 깎았습니다. (이게 클로저 스러운 방법이 아닌 걸까요?)

compare-str 도 compare나 diff 같은 함수를 찾아봤는데, 제가 딱 원하는 모양은 아니어서 깎았습니다.

문자열도 sequence로 사용하는 게 js나 다른 언어라고 불가능한 건 아니지만, 참 편리하구나 싶었습니다. 예를 들어 JS에서도 문자열에 iterator 프로토콜이 구현되어 있긴 하지만, string.map 메서드는 없어서 [...s].map(c => ???) 이 흔한 패턴입니다.

테스트 데이터를 원래 하드코딩해서 쓰다가 input-lines로 바꾸었는데요. 이 문제부터는 t라는 변수에 할당해놓은 뒤에, t에 먼저 값을 넣어보고, 그 밑에 input-lines로 실제 문제를 푸는 부분을 넣었습니다.

## 생각과 회고

제가 문제를 푸는 패턴을 보니까. 이름을 주고 hash-map을 만들기보다는 대부분 vector로 tuple을 만들더군요. 이러니 first나 second에 뭐가 들어있는지 기억해야 했고, 동적언어에서 의미가 불분명해지는 것처럼 느껴졌습니다. 이 생각은 문제 3까지 이어졌는데. 문제 4부터는 좀 더 값의 뜻을 명확하게 할 수 있는 방법을 찾아보려 합니다.
