### PR TITLE
advent of clojure 2018, day3 part2

### DIFF
--- a/aoc-2018/day3/day3.clj
+++ b/aoc-2018/day3/day3.clj
@@ -43,3 +43,24 @@
 (comment
   (answer-1 t)
   (answer-1 input-lines))
+
+(defn find-first
+  "조건을 만족하는 첫번째 요소를 찾아서 반환합니다"
+  [predicate seq]
+  (first (filter predicate seq)))
+
+(defn answer-2
+  [input]
+  (let [squares (->> input
+                     (map parse-line) ;; 입력을 예쁘게 시작점과 크기로 읽어서
+                     (map (fn [[start size id]] [id (points-of [start size])]))) ;; 점들로 변환하고
+        freq-dict (frequencies (mapcat second squares));; 빈도를 세어서
+        no-overlap? (fn [square] (every? (fn [point] (= (freq-dict point) 1)) square))]
+    (->> squares
+         (find-first (fn [[_id square]] (no-overlap? square))) ;; 겹치지 않는 사각형의
+         (first) ;; id는?
+         )))
+
+(comment
+  (answer-2 t) ;;  "#3"
+  (answer-2 input-lines)) 


### PR DESCRIPTION
## 문제를 풀며

앞에서 이미 칸마다 빈도수를 세고 있었습니다. 그러니 모든 칸의 빈도수가 1인 사각형이 있다면, overlap이 없는 거겠죠? 좀 비효율적일 수도 있지 않을까 싶은데. 일단 구현에 집중해보기로 했습니다.

js에는 find 메서드가 있는데. 클로저에서는 (first (filter 를 주로 사용하는 모양이더군요. (lazy하면 문제가 없을듯 합니다) 그래도 이름을 붙이면 좋겠어서 find-first라고 이름을 주고 주석도 달아 주었습니다.


## 회고와 생각

대부분의 문제를 지난 경험에서 풀었던 방식을 클로저에서도 비슷한 걸 찾아서 해결하고 있는데. 이게 클로저스러운 방식인지는 다른 사람들의 코드와 비교해보면서 고민해보려 합니다. (인터넷에는 aoc 풀이가 많으니까요)

지금까지는 단 한 번의 실패도 없이 한 번에 정답으로 나왔는데요. rescript에 test도 붙여서 풀 때에도, 테스트 값에서는 성공하는데, 실제 입력에서는 틀렸던 경우가 많아서. 이게 문제가 쉬운 건지 클로저가 대단한 건지 고민해보는 중 입니다.