### PR TITLE
advent of clojure 2018, day6 part2

### DIFF
--- a/aoc-2018/day6.clj
+++ b/aoc-2018/day6.clj
@@ -53,11 +53,16 @@
   [coordinate area]
   (count (filter #(= coordinate %) area)))
 
-(defn answer-1
+(defn grid-from-coordinates
   [coordinates]
   (let [width (apply max (map first coordinates))
         height (apply max (map last coordinates))
-        grid (rect width height)
+        grid (rect width height)]
+    grid))
+
+(defn answer-1
+  [coordinates]
+  (let [grid (grid-from-coordinates coordinates)
         border (filter (fn [[x y]] (or (zero? x) (zero? y) (= (inc width) x) (= (inc width) y))) grid)
         border-area (map #(closest % coordinates) border)
         area (map #(closest % coordinates) grid)
@@ -73,3 +78,27 @@
 (comment
   (answer-1 test-input)
   (answer-1 input))
+
+;; part 2
+
+(defn safe-location?
+  [limit coordinates from]
+  (->> coordinates
+       (map #(manhattan-distance from %))
+       (reduce +)
+       (#(> limit %))))
+
+(deftest safe-location?-test
+  (testing "Context of the test assertions"
+    (is (safe-location? 32 test-input [4 3]))))
+
+(defn answer-2
+  [coordinates limit]
+  (let [grid (grid-from-coordinates coordinates)]
+    (->> grid
+         (filter #(safe-location? limit coordinates %))
+         (count))))
+
+(comment
+  (answer-2 test-input 32)
+  (answer-2 input 10000))


### PR DESCRIPTION
- 앞에서 어려운 일을 다 끝내두었고, 특수하기보다는 일반적인 해법으로 풀어서인지... 이번에도 크게 어렵지 않았습니다. 공통 로직을 함수로 추출하고요.

신경 쓰이는 건 매개변수 여러 개를 우르르 넘겨야 하는 상황들인데. 보통 이러면 그냥 다 우르르 넘기는지 궁금하긴 합니다. 매개변수 순서에 의존하는 것도 신경 쓰이는데, 이런 때에는 js처럼 보통 hash-map으로 넘긴 다음에 분해를 하는 게 흔할까요?